### PR TITLE
Add React 18 entrypoint (`src/main.tsx`) with automatic `#root` fallback

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,20 @@
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import './index.css'
+import App from './App'
+
+function getMountNode(): HTMLElement {
+  const existing = document.getElementById('root')
+  if (existing) return existing
+
+  const fallback = document.createElement('div')
+  fallback.id = 'root'
+  document.body.appendChild(fallback)
+  return fallback
+}
+
+createRoot(getMountNode()).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+)


### PR DESCRIPTION
### Motivation

- Provide a React 18 application entrypoint and ensure the app mounts even when no `#root` element exists.

### Description

- Add `src/main.tsx` which imports `App`, ensures a `#root` mount node via `getMountNode()`, and uses `createRoot(getMountNode()).render()` inside `StrictMode` to mount the application.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd776ed1288320833d207e8fa0b245)