### PR TITLE
Add React entrypoint with startup error UI and set Vite base to relative path

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,51 @@
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import './index.css'
+import App from './App'
+
+function getMountNode(): HTMLElement {
+  const existing = document.getElementById('root')
+  if (existing) return existing
+
+  const fallback = document.createElement('div')
+  fallback.id = 'root'
+  document.body.appendChild(fallback)
+  return fallback
+}
+
+function renderFatalError(message: string): void {
+  const node = getMountNode()
+  node.innerHTML = ''
+
+  const panel = document.createElement('pre')
+  panel.textContent = message
+  panel.style.whiteSpace = 'pre-wrap'
+  panel.style.padding = '1rem'
+  panel.style.margin = '1rem'
+  panel.style.border = '2px solid #b91c1c'
+  panel.style.background = '#fef2f2'
+  panel.style.color = '#7f1d1d'
+  panel.style.fontFamily = 'ui-monospace, SFMono-Regular, Menlo, monospace'
+
+  node.appendChild(panel)
+}
+
+window.addEventListener('error', (event) => {
+  renderFatalError(`Startup error:\n${event.message}`)
+})
+
+window.addEventListener('unhandledrejection', (event) => {
+  const reason = event.reason instanceof Error ? event.reason.message : String(event.reason)
+  renderFatalError(`Unhandled promise rejection:\n${reason}`)
+})
+
+try {
+  createRoot(getMountNode()).render(
+    <StrictMode>
+      <App />
+    </StrictMode>,
+  )
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error)
+  renderFatalError(`Render failed:\n${message}`)
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,5 +3,6 @@ import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
 export default defineConfig({
+  base: './',
   plugins: [react()],
 })


### PR DESCRIPTION
### Motivation

- Provide a concrete application entrypoint that reliably mounts the React app even if the `#root` node is missing and surface clear error information on startup failures and unhandled promise rejections. 
- Ensure built assets are referenced using relative paths so the app can be served from subdirectories by setting the Vite `base` to a relative value.

### Description

- Add `src/main.tsx` which finds or creates the `#root` element and mounts `<App />` using `createRoot` inside `StrictMode` and imports `index.css`.
- Implement `renderFatalError` and global listeners for `error` and `unhandledrejection` to render readable error panels into the DOM when startup or promise errors occur.
- Wrap the initial render in a `try/catch` and display render failures via `renderFatalError` for synchronous exceptions during mount. 
- Update `vite.config.ts` to set `base: './'` so assets in production builds are resolved relatively.

### Testing

- Ran TypeScript type-check with `tsc --noEmit` and it completed successfully. 
- Executed a production build using `vite build` and the build finished without errors. 
- Started the dev server with `vite` and verified the app mounts and that the error UI appears for simulated startup and promise rejection errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd776ed1288320833d207e8fa0b245)